### PR TITLE
fix: nav menu visibility for small screen size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# editor config
+.vscode

--- a/src/App.css
+++ b/src/App.css
@@ -18,7 +18,3 @@ body {
 :root {
     --app-shell-padding: 0
 }
-
-.mantine-AppShell-header {
-    height: 35px;
-}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,17 @@ import { AppNavbar } from './components/AppNavbar';
 import '@mantine/core/styles.css';
 import '@mantine/notifications/styles.css';
 import './App.css';
+import { useNavBarToggler } from './hooks/useNavbarToggler';
 
 export const App = () => {
     const [route, setRoute] = useState<TRoute>('mocks');
+    const [isNavbarVisible, {toggle: toggleNavBar}] = useNavBarToggler();
+
+    const onRouteChange = (newRoute: TRoute) => {
+        setRoute(newRoute)
+
+        toggleNavBar()
+    }
 
     useEffect(() => {
         initStore();
@@ -33,13 +41,14 @@ export const App = () => {
                         header={{ height: 40 }}
                         navbar={{
                             width: 200,
-                            breakpoint: 'sm',
+                            breakpoint: 'xs',
+                            collapsed: {mobile: !isNavbarVisible}
                         }}
                         padding="md"
                     >
                         <AppNavbar
                             route={route}
-                            onRouteChange={setRoute}
+                            onRouteChange={onRouteChange}
                         />
 
                         <AppShell.Main

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,10 +1,14 @@
 import React, { FC } from 'react';
-import { Group, AppShell } from '@mantine/core';
+import { Group, AppShell, Burger } from '@mantine/core';
+import { useNavBarToggler } from '~/hooks/useNavbarToggler';
 
-export const Header: FC<React.PropsWithChildren> = ({ children }) => {
+export const Header: FC<React.PropsWithChildren > = ({ children }) => {
+    const [isNavbarVisible, {toggle}] = useNavBarToggler();
+
     return (
         <AppShell.Header>
             <Group h="100%" px="md" justify="space-between">
+                <Burger opened={isNavbarVisible} onClick={toggle} hiddenFrom="xs" size="sm" />
                 {children}
             </Group>
         </AppShell.Header>

--- a/src/hooks/useNavbarToggler.ts
+++ b/src/hooks/useNavbarToggler.ts
@@ -1,0 +1,15 @@
+import { TStore } from '~/types';
+import { useStore } from './useStore';
+
+export const useNavBarToggler = (): [TStore['settings']['showMobileNavBar'], { toggle: () => void }] => {
+    const [settings, setSettings] = useStore('settings');
+    const isNavbarVisible = settings?.showMobileNavBar || false;
+
+    const toggle = () => {
+        if (!settings) return;
+
+        setSettings({ ...settings, showMobileNavBar: !settings.showMobileNavBar });
+    };
+
+    return [isNavbarVisible, { toggle }];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export type TStoreSettings = {
     showNotifications: boolean;
     showActiveStatus: boolean;
     enabledHosts: Record<string, boolean>;
+    showMobileNavBar: boolean;
 };
 
 export type TStore = {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -12,6 +12,7 @@ const emptyStore: TStore = {
         showNotifications: true,
         showActiveStatus: true,
         enabledHosts: {},
+        showMobileNavBar: false,
     },
 };
 


### PR DESCRIPTION
Если окно девтулз очень узкое, то видно только навигацию
По переключению ничего не происходит
Пришлось немного попотеть, чтобы понять как пользоваться расширением =)

Данные пр фиксит эту проблему