### PR TITLE
Mocks DnD

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,8 @@
         "react/function-component-definition": "off",
         "react/jsx-filename-extension": [1, { "extensions": [".tsx"] }],
         "react/jsx-props-no-spreading": "off",
-        "react/jsx-one-expression-per-line": "off"
+        "react/jsx-one-expression-per-line": "off",
+        "no-plusplus": "off"
     },
     "settings": {
         "import/resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
         "": {
             "name": "mockiato",
             "dependencies": {
+                "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+                "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
+                "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^3.2.12",
                 "@mantine/core": "^7.13.4",
                 "@mantine/form": "^7.13.4",
                 "@mantine/hooks": "^7.13.4",
@@ -64,6 +67,115 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@atlaskit/atlassian-context": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/atlassian-context/-/atlassian-context-0.6.1.tgz",
+            "integrity": "sha512-NZRjUyVeLXjV1A3AsSBUL8sKN3Y2gIsf32M3pq+8pGeEhLFDdLqDSVH/mBiyuA1U7XmeoRecSe2ZgZiNr2TE4w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@atlaskit/ds-lib": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/ds-lib/-/ds-lib-6.0.0.tgz",
+            "integrity": "sha512-hLN10kpRSrx27Pzn6+kKaO8R6/8gWvPuHvD0hJEk4Pi/M4Ws0rWdM4Zo3b1HgP2DW9dLWYuEwI6Bi6OPf2J7Dg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "tiny-invariant": "^1.2.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@atlaskit/feature-gate-js-client": {
+            "version": "5.5.9",
+            "resolved": "https://registry.npmjs.org/@atlaskit/feature-gate-js-client/-/feature-gate-js-client-5.5.9.tgz",
+            "integrity": "sha512-VNUVeWeNt3MY1eiMqjeKwx64I+gUrzHPN9nJHkIs2uAGxuvGr4+329zJlzUefUtwJW9yIQYcqhJKfm6ZvmXuYQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/atlassian-context": "^0.6.0",
+                "@babel/runtime": "^7.0.0",
+                "@statsig/client-core": "^3.27.0",
+                "@statsig/js-client": "^3.27.0",
+                "eventemitter3": "^4.0.0"
+            }
+        },
+        "node_modules/@atlaskit/feature-gate-js-client/node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "license": "MIT"
+        },
+        "node_modules/@atlaskit/platform-feature-flags": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@atlaskit/platform-feature-flags/-/platform-feature-flags-1.1.3.tgz",
+            "integrity": "sha512-dRn6UvVmMF5+WXnv7ZlxKTV2rVQncI2TgM0KTGSqpHdD9LnogITWC/rFjzUuF/W8MBCEvpouGilukqhq6rASnw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/feature-gate-js-client": "^5.5.0",
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+            "version": "1.7.9",
+            "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.7.9.tgz",
+            "integrity": "sha512-m/bcw5flyjfcF/rdX4JeomtIBrWuDNOwcQieiywHv7zkfIRmUC34Q9ZLeNGVoz73UiGsRqxysMuw4tC7lSJ89g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@babel/runtime": "^7.0.0",
+                "bind-event-listener": "^3.0.0",
+                "raf-schd": "^4.0.3"
+            }
+        },
+        "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.1.0.tgz",
+            "integrity": "sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/pragmatic-drag-and-drop": "^1.6.0",
+                "@babel/runtime": "^7.0.0"
+            }
+        },
+        "node_modules/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": {
+            "version": "3.2.12",
+            "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/-/pragmatic-drag-and-drop-react-drop-indicator-3.2.12.tgz",
+            "integrity": "sha512-4Yza7zfwY8g8eP+a528mdN5lZVHm9GM1WJ9Jxd6u6hO7MJUznOUdYVDP/MoJFxPm5DnHcdtKwFJ/IRXejaD0fQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/pragmatic-drag-and-drop": "^1.7.0",
+                "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
+                "@atlaskit/tokens": "^11.0.0",
+                "@babel/runtime": "^7.0.0",
+                "@compiled/react": "^0.18.6"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0 || ^19.0.0"
+            }
+        },
+        "node_modules/@atlaskit/tokens": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/@atlaskit/tokens/-/tokens-11.1.1.tgz",
+            "integrity": "sha512-JhwthtC047LaLXGL3iUgTGXfIrwecue/RmCbO/sk3yscxy04bbt+LgKwxlv+7l21BkhhvPeE+d34Lz/+uUCJCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@atlaskit/ds-lib": "^6.0.0",
+                "@atlaskit/platform-feature-flags": "^1.1.0",
+                "@babel/runtime": "^7.0.0",
+                "@babel/traverse": "^7.23.2",
+                "@babel/types": "^7.20.0",
+                "bind-event-listener": "^3.0.0"
+            },
+            "peerDependencies": {
+                "react": "^18.2.0 || ^19.0.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -2132,6 +2244,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@compiled/react": {
+            "version": "0.18.6",
+            "resolved": "https://registry.npmjs.org/@compiled/react/-/react-0.18.6.tgz",
+            "integrity": "sha512-Mt6sJOwykeoToEBFbOUNR4xABi2gOr/+X5QSGqGEYiCBMh+XPDAclG2UX94zveiYJXO4AUJIQBCVwa4/lwPMBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "csstype": "^3.1.3"
+            },
+            "peerDependencies": {
+                "react": ">= 16.12.0"
             }
         },
         "node_modules/@csstools/css-parser-algorithms": {
@@ -4321,6 +4445,21 @@
             "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw==",
             "license": "ISC"
         },
+        "node_modules/@statsig/client-core": {
+            "version": "3.32.2",
+            "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.32.2.tgz",
+            "integrity": "sha512-aODmryOeV2oOtmPKShuw08VxnuzNLKkXwezMtcbPWuDbf6ft9rwzlwgZYBxe88U57T6kXewgkk/sx6LcreWr+g==",
+            "license": "ISC"
+        },
+        "node_modules/@statsig/js-client": {
+            "version": "3.32.2",
+            "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.32.2.tgz",
+            "integrity": "sha512-YuZ0OXYG4SnuS3Iu06f8KpXK+V/YskxirtXyrqBxh/cqvLuCvtPSSEyG/MCOEvfJ/nbKAfdK0dI929FzhFI8aQ==",
+            "license": "ISC",
+            "dependencies": {
+                "@statsig/client-core": "3.32.2"
+            }
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -5807,6 +5946,12 @@
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/bind-event-listener": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+            "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q==",
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
@@ -10747,6 +10892,12 @@
             ],
             "license": "MIT"
         },
+        "node_modules/raf-schd": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+            "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
+            "license": "MIT"
+        },
         "node_modules/react": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -12463,6 +12614,12 @@
                 "readable-stream": "~1.0.17",
                 "xtend": "~2.1.1"
             }
+        },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+            "license": "MIT"
         },
         "node_modules/tinybench": {
             "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
     "private": true,
     "type": "module",
     "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.7.9",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
+        "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator": "^3.2.12",
         "@mantine/core": "^7.13.4",
         "@mantine/form": "^7.13.4",
         "@mantine/hooks": "^7.13.4",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "Mockiato — Free API Testing & Mocking Tool",
     "description": "Chrome extension to intercept requests, create real-time mocks, and auto-insert headers for web development & testing API.",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "devtools_page": "devtools.html",
     "icons": {
         "16": "icons/mockiato-16.png",

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,11 +1,12 @@
+import { forwardRef } from 'react';
 import { Paper, PaperProps } from '@mantine/core';
-import { FC } from 'react';
 
 type CardProps = import('@mantine/utils').PolymorphicComponentProps<'div', PaperProps>
 
-export const Card: FC<CardProps> = ({ children, ...rest }) => {
+export const Card = forwardRef<HTMLDivElement, CardProps>(({ children, ...rest }, ref) => {
     return (
         <Paper
+            ref={ref}
             shadow="sm"
             radius="md"
             p="md"
@@ -15,4 +16,4 @@ export const Card: FC<CardProps> = ({ children, ...rest }) => {
             {children}
         </Paper>
     );
-};
+});

--- a/src/pages/Mocks/Mocks.tsx
+++ b/src/pages/Mocks/Mocks.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useReducer, useState, useMemo, useEffect } from 'react';
+import React, { memo, useReducer, useState, useMemo, useEffect, useCallback } from 'react';
 import { Drawer } from '@mantine/core';
 import { showNotification } from '@mantine/notifications';
 import { nanoid } from 'nanoid';
@@ -19,6 +19,13 @@ const initialMockFormState: TMockFormState = {
     isOpened: false,
     mock: undefined,
 };
+
+function arrayMove<T>(arr: T[], from: number, to: number): T[] {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item);
+    return result;
+}
 
 const mockFormReducer = (state: TMockFormState, action: TMockFormAction): TMockFormState => {
     switch (action.type) {
@@ -80,6 +87,21 @@ const MocksPage: React.FC = () => {
             payload: mock,
         });
     };
+
+    const handleUpdateMocks = useCallback((newMocks: TMock[]) => {
+        setMocks(newMocks);
+    }, [setMocks]);
+
+    const handleReorderGroups = useCallback((activeId: string, overId: string) => {
+        if (!groups) return;
+
+        const oldIndex = groups.findIndex((g) => g.id === activeId);
+        const newIndex = groups.findIndex((g) => g.id === overId);
+
+        if (oldIndex === -1 || newIndex === -1) return;
+
+        setGroups(arrayMove(groups, oldIndex, newIndex));
+    }, [groups, setGroups]);
 
     if (!mocks || !groups) {
         return <Spinner />;
@@ -228,6 +250,8 @@ const MocksPage: React.FC = () => {
                     onDeleteGroup={handleDeleteGroup}
                     onClearGroup={handleClearGroup}
                     onToggleMocks={handleToggleMocksInGroup}
+                    onReorderGroups={handleReorderGroups}
+                    onUpdateMocks={handleUpdateMocks}
                 />
             ) : (
                 <NotFound text="No mocks to show" />

--- a/src/pages/Mocks/components/Content/Content.module.css
+++ b/src/pages/Mocks/components/Content/Content.module.css
@@ -4,6 +4,10 @@
     gap: .625rem;
 }
 
+.drag {
+    width: 22px;
+}
+
 .status {
     width: 35px;
 }
@@ -19,3 +23,16 @@
 .code {
     width: 134px;
 }
+
+.ungroupedDropZone {
+    min-height: 40px;
+    border-radius: 8px;
+}
+
+.ungroupedDropZoneEmpty {
+    border: 2px dashed var(--mantine-color-gray-4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+

--- a/src/pages/Mocks/components/Content/Content.tsx
+++ b/src/pages/Mocks/components/Content/Content.tsx
@@ -1,6 +1,8 @@
-import React, { FC, useMemo } from 'react';
+import React, { FC, useEffect, useMemo, useRef } from 'react';
 import { Stack, Text } from '@mantine/core';
 import { modals } from '@mantine/modals';
+import { monitorForElements, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { TMock, TMockGroup } from '~/types';
 import { filterMocks } from '~/utils/filterMocks';
 import { Mock } from './components/Mock';
@@ -19,7 +21,61 @@ type ContentProps = {
     onDeleteGroup: (groupId: TMockGroup['id']) => void;
     onClearGroup: (groupId: TMockGroup['id']) => void;
     onToggleMocks: (groupId: TMockGroup['id'], status: boolean) => void;
+    onReorderGroups: (activeId: string, overId: string) => void;
+    onUpdateMocks: (mocks: TMock[]) => void;
 };
+
+const TableHeader = () => (
+    <div className={styles.tableHeader}>
+        <Text size="xs" c="dimmed" className={styles.drag}>{' '}</Text>
+        <Text size="xs" c="dimmed" className={styles.status}>{' '}</Text>
+        <Text size="xs" c="dimmed" className={styles.method}>Method</Text>
+        <Text size="xs" c="dimmed" className={styles.url}>URL</Text>
+        <Text size="xs" c="dimmed" className={styles.code}>Code</Text>
+    </div>
+);
+
+const UngroupedDropZone: FC<React.PropsWithChildren<{ isEmpty: boolean }>> = ({ children, isEmpty }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const [isDraggedOver, setIsDraggedOver] = React.useState(false);
+
+    useEffect(() => {
+        if (!ref.current) {
+            return undefined;
+        }
+
+        return dropTargetForElements({
+            element: ref.current,
+            canDrop: ({ source }) => source.data.type === 'mock',
+            getData: () => ({ type: 'ungrouped' }),
+            onDragEnter: () => setIsDraggedOver(true),
+            onDragLeave: () => setIsDraggedOver(false),
+            onDrop: () => setIsDraggedOver(false),
+        });
+    }, []);
+
+    const className = [
+        styles.ungroupedDropZone,
+        isEmpty ? styles.ungroupedDropZoneEmpty : '',
+    ].filter(Boolean).join(' ');
+
+    return (
+        <div
+            ref={ref}
+            className={className}
+            style={isDraggedOver && isEmpty ? { borderColor: 'var(--mantine-color-blue-5)' } : undefined}>
+            {isEmpty && isDraggedOver && <Text size="sm" c="dimmed">Drop here to ungroup</Text>}
+            {children}
+        </div>
+    );
+};
+
+function arrayMove<T>(arr: T[], from: number, to: number): T[] {
+    const result = [...arr];
+    const [item] = result.splice(from, 1);
+    result.splice(to, 0, item);
+    return result;
+}
 
 export const Content: FC<ContentProps> = ({
     mocks,
@@ -33,8 +89,10 @@ export const Content: FC<ContentProps> = ({
     onDeleteGroup,
     onClearGroup,
     onToggleMocks,
+    onReorderGroups,
+    onUpdateMocks,
 }) => {
-    const { emptyGroups, emptyMocks, mocksByGroups } = useMemo(() => {
+    const { ungroupedMocks, groupsWithMocks } = useMemo(() => {
         return filterMocks(mocks, groups);
     }, [mocks, groups]);
 
@@ -61,15 +119,143 @@ export const Content: FC<ContentProps> = ({
 
     const handleRemoveMocks = (group: TMockGroup) => onClearGroup(group.id);
 
+    const moveMockToGroup = (mockId: string, targetGroupId: string | null, overMockId: string | null) => {
+        const mockToMove = mocks.find((m) => m.id === mockId);
+        if (!mockToMove) return;
+
+        const updated = { ...mockToMove };
+        if (targetGroupId) {
+            updated.groupId = targetGroupId;
+        } else {
+            delete updated.groupId;
+        }
+
+        const without = mocks.filter((m) => m.id !== mockId);
+
+        if (overMockId) {
+            const overIdx = without.findIndex((m) => m.id === overMockId);
+            without.splice(overIdx, 0, updated);
+        } else if (targetGroupId) {
+            let lastIdx = -1;
+            for (let i = without.length - 1; i >= 0; i--) {
+                if (without[i].groupId === targetGroupId) {
+                    lastIdx = i;
+                    break;
+                }
+            }
+            without.splice(lastIdx + 1, 0, updated);
+        } else {
+            without.push(updated);
+        }
+
+        onUpdateMocks(without);
+    };
+
+    // Monitor for all drag-and-drop events
+    useEffect(() => {
+        return monitorForElements({
+            onDrop: ({ source, location }) => {
+                const target = location.current.dropTargets[0];
+                if (!target) return;
+
+                const sourceType = source.data.type;
+                const targetType = target.data.type;
+
+                // Group reorder
+                if (sourceType === 'group' && targetType === 'group') {
+                    const sourceGroupId = source.data.groupId as string;
+                    const targetGroupId = target.data.groupId as string;
+                    if (sourceGroupId === targetGroupId) return;
+
+                    const edge = extractClosestEdge(target.data);
+                    const oldIdx = groups.findIndex((g) => g.id === sourceGroupId);
+                    const newIdx = groups.findIndex((g) => g.id === targetGroupId);
+                    if (oldIdx === -1 || newIdx === -1) return;
+
+                    // Adjust index based on edge
+                    let finalIdx = newIdx;
+                    if (edge === 'bottom' && oldIdx < newIdx) {
+                        finalIdx = newIdx;
+                    } else if (edge === 'top' && oldIdx > newIdx) {
+                        finalIdx = newIdx;
+                    } else if (edge === 'bottom' && oldIdx > newIdx) {
+                        finalIdx = newIdx + 1;
+                    } else if (edge === 'top' && oldIdx < newIdx) {
+                        finalIdx = newIdx - 1;
+                    }
+
+                    onReorderGroups(sourceGroupId, groups[finalIdx]?.id ?? targetGroupId);
+                    return;
+                }
+
+                if (sourceType !== 'mock') return;
+
+                const sourceMockId = source.data.mockId as string;
+
+                // Mock dropped on another mock
+                if (targetType === 'mock') {
+                    const targetMockId = target.data.mockId as string;
+                    const sourceGroupId = source.data.groupId as string | null;
+                    const targetGroupId = target.data.groupId as string | null;
+                    const edge = extractClosestEdge(target.data);
+
+                    if (sourceGroupId === targetGroupId) {
+                        // Same group reorder
+                        const subset = mocks.filter((m) =>
+                            sourceGroupId ? m.groupId === sourceGroupId : !m.groupId,
+                        );
+                        const oldIdx = subset.findIndex((m) => m.id === sourceMockId);
+                        const newIdx = subset.findIndex((m) => m.id === targetMockId);
+
+                        if (oldIdx !== -1 && newIdx !== -1 && oldIdx !== newIdx) {
+                            // Adjust for edge
+                            let adjustedIdx = newIdx;
+                            if (edge === 'bottom' && oldIdx < newIdx) {
+                                adjustedIdx = newIdx;
+                            } else if (edge === 'top' && oldIdx > newIdx) {
+                                adjustedIdx = newIdx;
+                            } else if (edge === 'bottom' && oldIdx > newIdx) {
+                                adjustedIdx = newIdx + 1;
+                            } else if (edge === 'top' && oldIdx < newIdx) {
+                                adjustedIdx = newIdx - 1;
+                            }
+
+                            const reordered = arrayMove(subset, oldIdx, adjustedIdx);
+                            let ri = 0;
+                            const finalMocks = mocks.map((m) => {
+                                const belongs = sourceGroupId ? m.groupId === sourceGroupId : !m.groupId;
+                                return belongs ? reordered[ri++] : m;
+                            });
+                            onUpdateMocks(finalMocks);
+                        }
+                    } else {
+                        // Cross-group move
+                        moveMockToGroup(sourceMockId, targetGroupId, targetMockId);
+                    }
+                }
+                // Mock dropped on a group header
+                else if (targetType === 'group') {
+                    const targetGroupId = target.data.groupId as string;
+                    moveMockToGroup(sourceMockId, targetGroupId, null);
+                }
+                // Mock dropped on ungrouped zone
+                else if (targetType === 'ungrouped') {
+                    moveMockToGroup(sourceMockId, null, null);
+                }
+            },
+        });
+    }, [mocks, groups, onReorderGroups, onUpdateMocks]);
+
     return (
         <Stack gap="xl">
-            {Object.values(mocksByGroups).length > 0 && (
+            {groupsWithMocks.length > 0 && (
                 <Stack gap="xs">
-                    {Object.values(mocksByGroups).map((value) => (
+                    {groupsWithMocks.map((value, groupIndex) => (
                         <MockGroup
                             key={value.group.id}
                             group={value.group}
                             mocks={value.mocks}
+                            isLast={groupIndex === groupsWithMocks.length - 1}
                             isExpanded={expandedGroups.has(value.group.id)}
                             onToggleGroup={(isExpanded) => onToggleGroup(value.group.id, isExpanded)}
                             onDeleteGroup={handleDeleteGroup}
@@ -77,119 +263,45 @@ export const Content: FC<ContentProps> = ({
                             onEnableAll={(group) => onToggleMocks(group.id, true)}
                             onDisableAll={(group) => onToggleMocks(group.id, false)}
                         >
-                            <>
-                                <div className={styles.tableHeader}>
-                                    <Text
-                                        size="xs"
-                                        c="dimmed"
-                                        className={styles.status}
-                                    >
-                                        {' '}
-                                    </Text>
-                                    <Text
-                                        size="xs"
-                                        c="dimmed"
-                                        className={styles.method}
-                                    >
-                                        Method
-                                    </Text>
-                                    <Text
-                                        size="xs"
-                                        c="dimmed"
-                                        className={styles.url}
-                                    >
-                                        URL
-                                    </Text>
-                                    <Text
-                                        size="xs"
-                                        c="dimmed"
-                                        className={styles.code}
-                                    >
-                                        Code
-                                    </Text>
-                                </div>
-
-                                <Stack gap="xs">
-                                    {value.mocks.map((mock: TMock) => (
-                                        <Mock
-                                            key={mock.id}
-                                            mock={mock}
-                                            onEditClick={onEditMock}
-                                            onCopyClick={onCopyMock}
-                                            onDelete={onDeleteMock}
-                                            onChange={onChangeMock}
-                                        />
-                                    ))}
-                                </Stack>
-                            </>
+                            {value.mocks.length > 0 && <TableHeader />}
+                            <Stack gap="xs">
+                                {value.mocks.map((mock, mockIndex) => (
+                                    <Mock
+                                        key={mock.id}
+                                        mock={mock}
+                                        isLast={mockIndex === value.mocks.length - 1}
+                                        onEditClick={onEditMock}
+                                        onCopyClick={onCopyMock}
+                                        onDelete={onDeleteMock}
+                                        onChange={onChangeMock}
+                                    />
+                                ))}
+                            </Stack>
                         </MockGroup>
                     ))}
                 </Stack>
             )}
 
-            {emptyMocks.length > 0 && (
-                <div>
-                    <div className={styles.tableHeader}>
-                        <Text
-                            size="xs"
-                            c="dimmed"
-                            className={styles.status}
-                        >
-                            {' '}
-                        </Text>
-                        <Text
-                            size="xs"
-                            c="dimmed"
-                            className={styles.method}
-                        >
-                            Method
-                        </Text>
-                        <Text
-                            size="xs"
-                            c="dimmed"
-                            className={styles.url}
-                        >
-                            URL
-                        </Text>
-                        <Text
-                            size="xs"
-                            c="dimmed"
-                            className={styles.code}
-                        >
-                            Code
-                        </Text>
-                    </div>
-
-                    <Stack gap="xs">
-                        {emptyMocks.map((mock) => (
-                            <Mock
-                                key={mock.id}
-                                mock={mock}
-                                onEditClick={onEditMock}
-                                onCopyClick={onCopyMock}
-                                onDelete={onDeleteMock}
-                                onChange={onChangeMock}
-                            />
-                        ))}
-                    </Stack>
-                </div>
-            )}
-
-            {emptyGroups.length > 0 && (
-                <Stack gap="xs">
-                    <Text c="dimmed">Empty groups</Text>
-
-                    {emptyGroups.map((group) => (
-                        <MockGroup
-                            key={group.id}
-                            group={group}
-                            isExpanded={expandedGroups.has(group.id)}
-                            onToggleGroup={(isExpanded) => onToggleGroup(group.id, isExpanded)}
-                            onDeleteGroup={handleDeleteGroup}
-                        />
-                    ))}
-                </Stack>
-            )}
+            <UngroupedDropZone isEmpty={ungroupedMocks.length === 0}>
+                {ungroupedMocks.length > 0 && (
+                    <>
+                        <TableHeader />
+                        <Stack gap="xs">
+                            {ungroupedMocks.map((mock, idx) => (
+                                <Mock
+                                    key={mock.id}
+                                    mock={mock}
+                                    isLast={idx === ungroupedMocks.length - 1}
+                                    onEditClick={onEditMock}
+                                    onCopyClick={onCopyMock}
+                                    onDelete={onDeleteMock}
+                                    onChange={onChangeMock}
+                                />
+                            ))}
+                        </Stack>
+                    </>
+                )}
+            </UngroupedDropZone>
         </Stack>
     );
 };

--- a/src/pages/Mocks/components/Content/components/Mock/Mock.module.css
+++ b/src/pages/Mocks/components/Content/components/Mock/Mock.module.css
@@ -30,3 +30,12 @@
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+.dragHandle {
+    cursor: grab;
+    touch-action: none;
+}
+
+.dragHandle:active {
+    cursor: grabbing;
+}

--- a/src/pages/Mocks/components/Content/components/Mock/Mock.tsx
+++ b/src/pages/Mocks/components/Content/components/Mock/Mock.tsx
@@ -1,6 +1,11 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import { ActionIcon, Group, Switch, Text, Tooltip, useMantineTheme } from '@mantine/core';
-import { IconEdit, IconCopy, IconInfoCircle, IconTrash, IconRegex } from '@tabler/icons-react';
+import { IconEdit, IconCopy, IconInfoCircle, IconTrash, IconRegex, IconGripVertical } from '@tabler/icons-react';
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import {
+    attachClosestEdge, extractClosestEdge, type Edge,
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
 import { HttpMethod } from '../../../../../../components/HttpMethod';
 import { HttpStatus } from '../../../../../../components/HttpStatus';
 import { Card } from '../../../../../../components/Card';
@@ -11,16 +16,62 @@ import styles from './Mock.module.css';
 
 interface MockProps {
     mock: TMock;
+    isLast?: boolean;
     onEditClick: (mock: TMock) => void;
     onCopyClick: (mock: TMock) => void;
     onChange: (mock: TMock) => void;
     onDelete: (mockId: string) => void;
 }
 
-export const Mock: FC<MockProps> = ({ mock, onDelete, onChange, onCopyClick, onEditClick }) => {
+export const Mock: FC<MockProps> = ({ mock, isLast, onDelete, onChange, onCopyClick, onEditClick }) => {
+    const ref = useRef<HTMLDivElement>(null);
+    const dragHandleRef = useRef<HTMLButtonElement>(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
+
     const theme = useMantineTheme();
     const [settings] = useStore('settings');
     const isInlineComment = settings?.commentDisplayMode === 'inline';
+
+    useEffect(() => {
+        const el = ref.current;
+        const handle = dragHandleRef.current;
+        if (!el || !handle) return undefined;
+
+        const cleanupDraggable = draggable({
+            element: el,
+            dragHandle: handle,
+            getInitialData: () => ({ type: 'mock', mockId: mock.id, groupId: mock.groupId ?? null }),
+            onDragStart: () => setIsDragging(true),
+            onDrop: () => setIsDragging(false),
+        });
+
+        const cleanupDropTarget = dropTargetForElements({
+            element: el,
+            canDrop: ({ source }) => source.data.type === 'mock' && source.data.mockId !== mock.id,
+            getData: ({ input, element }) => {
+                return attachClosestEdge(
+                    { type: 'mock', mockId: mock.id, groupId: mock.groupId ?? null },
+                    { element, input, allowedEdges: ['top', 'bottom'] },
+                );
+            },
+            onDragEnter: ({ self }) => {
+                const edge = extractClosestEdge(self.data);
+                setClosestEdge(edge === 'bottom' && !isLast ? null : edge);
+            },
+            onDrag: ({ self }) => {
+                const edge = extractClosestEdge(self.data);
+                setClosestEdge(edge === 'bottom' && !isLast ? null : edge);
+            },
+            onDragLeave: () => setClosestEdge(null),
+            onDrop: () => setClosestEdge(null),
+        });
+
+        return () => {
+            cleanupDraggable();
+            cleanupDropTarget();
+        };
+    }, [mock.id, mock.groupId, isLast]);
 
     const handleDelete = (e: React.MouseEvent<HTMLButtonElement>): void => {
         if (e.detail < 2) {
@@ -41,128 +92,144 @@ export const Mock: FC<MockProps> = ({ mock, onDelete, onChange, onCopyClick, onE
     const handleEditClick = (): void => onEditClick(mock);
 
     return (
-        <Card
-            key={mock.id}
-            p="0.34rem 0.6rem"
-        >
-            <Group gap="xs">
-                <Switch
-                    onLabel="ON"
-                    offLabel="OFF"
-                    size="xs"
-                    checked={mock.isActive}
-                    title="Enable/disable mock"
-                    onChange={handleChangeStatus}
-                />
-
-                <div className={styles.method}>
-                    <HttpMethod method={mock.httpMethod} />
-                </div>
-
-                <Group
-                    align="center"
-                    className={styles.url}
-                    gap="xs"
-                >
-                    <Text
-                        size="xs"
-                        title={mock.url}
-                        className={styles.urlText}
+        <div style={{ position: 'relative' }}>
+            <Card
+                key={mock.id}
+                p="0.34rem 0.6rem"
+                ref={ref}
+                style={{ opacity: isDragging ? 0.4 : undefined }}
+            >
+                <Group gap="xs">
+                    <ActionIcon
+                        ref={dragHandleRef}
+                        className={styles.dragHandle}
+                        variant="subtle"
+                        color="gray"
+                        size="sm"
                     >
-                        {mock.url}
-                    </Text>
+                        <IconGripVertical size={14} />
+                    </ActionIcon>
 
-                    {mock.urlType === 'regexp' && (
+                    <Switch
+                        onLabel="ON"
+                        offLabel="OFF"
+                        size="xs"
+                        checked={mock.isActive}
+                        title="Enable/disable mock"
+                        onChange={handleChangeStatus}
+                    />
+
+                    <div className={styles.method}>
+                        <HttpMethod method={mock.httpMethod} />
+                    </div>
+
+                    <Group
+                        align="center"
+                        className={styles.url}
+                        gap="xs"
+                    >
+                        <Text
+                            size="xs"
+                            title={mock.url}
+                            className={styles.urlText}
+                        >
+                            {mock.url}
+                        </Text>
+
+                        {mock.urlType === 'regexp' && (
+                            <Tooltip
+                                label="RegExp enabled"
+                                position="bottom"
+                                transitionProps={{ transition: 'scale' }}
+                                openDelay={150}
+                                withArrow
+                            >
+                                <IconRegex
+                                    size={16}
+                                    color="#9775fa"
+                                />
+                            </Tooltip>
+                        )}
+
+                        {mock.comment && (
+                            isInlineComment ? (
+                                <Text
+                                    size="xs"
+                                    c="dimmed"
+                                    className={styles.commentInline}
+                                    title={mock.comment}
+                                >
+                                    {mock.comment}
+                                </Text>
+                            ) : (
+                                <Tooltip
+                                    label={mock.comment}
+                                    withArrow
+                                    multiline
+                                    maw={300}
+                                    position="bottom"
+                                    className={styles.comment}
+                                >
+                                    <span>
+                                        <IconInfoCircle
+                                            size={16}
+                                            color={theme.colors.blue[4]}
+                                        />
+                                    </span>
+                                </Tooltip>
+                            )
+                        )}
+                    </Group>
+
+                    <Group className={styles.code}>
+                        <HttpStatus status={mock.httpStatusCode} />
+                    </Group>
+
+                    <Group gap="0.4rem">
                         <Tooltip
-                            label="RegExp enabled"
+                            label="Double click to delete"
                             position="bottom"
-                            transitionProps={{ transition: 'scale' }}
-                            openDelay={150}
+                            transitionProps={{ transition: 'scale-y' }}
+                            openDelay={300}
                             withArrow
                         >
-                            <IconRegex
-                                size={16}
-                                color="#9775fa"
-                            />
+                            <ActionIcon
+                                variant="subtle"
+                                color="red"
+                                size="sm"
+                                radius="sm"
+                                onClick={handleDelete}
+                            >
+                                <IconTrash size={iconSize} />
+                            </ActionIcon>
                         </Tooltip>
-                    )}
 
-                    {mock.comment && (
-                        isInlineComment ? (
-                            <Text
-                                size="xs"
-                                c="dimmed"
-                                className={styles.commentInline}
-                                title={mock.comment}
-                            >
-                                {mock.comment}
-                            </Text>
-                        ) : (
-                            <Tooltip
-                                label={mock.comment}
-                                withArrow
-                                multiline
-                                maw={300}
-                                position="bottom"
-                                className={styles.comment}
-                            >
-                                <span>
-                                    <IconInfoCircle
-                                        size={16}
-                                        color={theme.colors.blue[4]}
-                                    />
-                                </span>
-                            </Tooltip>
-                        )
-                    )}
-                </Group>
-
-                <Group className={styles.code}>
-                    <HttpStatus status={mock.httpStatusCode} />
-                </Group>
-
-                <Group gap="0.4rem">
-                    <Tooltip
-                        label="Double click to delete"
-                        position="bottom"
-                        transitionProps={{ transition: 'scale-y' }}
-                        openDelay={300}
-                        withArrow
-                    >
                         <ActionIcon
                             variant="subtle"
-                            color="red"
+                            color="cyan"
                             size="sm"
                             radius="sm"
-                            onClick={handleDelete}
+                            title="Clone mock"
+                            onClick={handleCopy}
                         >
-                            <IconTrash size={iconSize} />
+                            <IconCopy size={iconSize} />
                         </ActionIcon>
-                    </Tooltip>
 
-                    <ActionIcon
-                        variant="subtle"
-                        color="cyan"
-                        size="sm"
-                        radius="sm"
-                        title="Clone mock"
-                        onClick={handleCopy}
-                    >
-                        <IconCopy size={iconSize} />
-                    </ActionIcon>
-
-                    <ActionIcon
-                        variant="subtle"
-                        color="blue"
-                        size="sm"
-                        radius="sm"
-                        title="Edit mock"
-                        onClick={handleEditClick}
-                    >
-                        <IconEdit size={iconSize} />
-                    </ActionIcon>
+                        <ActionIcon
+                            variant="subtle"
+                            color="blue"
+                            size="sm"
+                            radius="sm"
+                            title="Edit mock"
+                            onClick={handleEditClick}
+                        >
+                            <IconEdit size={iconSize} />
+                        </ActionIcon>
+                    </Group>
                 </Group>
-            </Group>
-        </Card>
+            </Card>
+            
+            {closestEdge && <DropIndicator edge={closestEdge} gap="0.25rem" />}
+        </div>
     );
 };

--- a/src/pages/Mocks/components/Content/components/MockGroup/MockGroup.module.css
+++ b/src/pages/Mocks/components/Content/components/MockGroup/MockGroup.module.css
@@ -1,3 +1,12 @@
+.dragHandle {
+    cursor: grab;
+    touch-action: none;
+}
+
+.dragHandle:active {
+    cursor: grabbing;
+}
+
 .root {
     border: 1px dashed;
     border-radius: 6px;
@@ -17,6 +26,11 @@
 
 .groupName:hover {
     text-decoration: underline;
+}
+
+.draggedOver {
+    outline: 2px solid var(--mantine-primary-color-filled);
+    outline-offset: -2px;
 }
 
 @media (prefers-color-scheme: light) {

--- a/src/pages/Mocks/components/Content/components/MockGroup/MockGroup.tsx
+++ b/src/pages/Mocks/components/Content/components/MockGroup/MockGroup.tsx
@@ -1,20 +1,27 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useRef, useState } from 'react';
 import { ActionIcon, Collapse, Group, Menu, Text } from '@mantine/core';
 import {
     IconChevronDown,
     IconChevronUp,
     IconCircleOff,
     IconDotsVertical,
+    IconGripVertical,
     IconPower,
     IconTrash,
 } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
+import { draggable, dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter';
+import {
+    attachClosestEdge, extractClosestEdge, type Edge,
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
+import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
 import { TMock, TMockGroup } from '../../../../../../types';
 import styles from './MockGroup.module.css';
 
 type MockGroupProps = React.PropsWithChildren & {
     group: TMockGroup;
     mocks?: TMock[];
+    isLast?: boolean;
     isExpanded?: boolean;
     onToggleGroup?: (isExpanded: boolean) => void;
     onDeleteGroup: (group: TMockGroup) => void;
@@ -27,6 +34,7 @@ export const MockGroup: FC<MockGroupProps> = ({
     group,
     children,
     mocks = [],
+    isLast,
     isExpanded = true,
     onToggleGroup,
     onDeleteGroup,
@@ -35,6 +43,68 @@ export const MockGroup: FC<MockGroupProps> = ({
     onDisableAll,
 }) => {
     const [isOpen, { toggle, open, close }] = useDisclosure(true);
+    const ref = useRef<HTMLDivElement>(null);
+    const dragHandleRef = useRef<HTMLButtonElement>(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
+    const [isMockDraggedOver, setIsMockDraggedOver] = useState(false);
+
+    useEffect(() => {
+        const el = ref.current;
+        const handle = dragHandleRef.current;
+        if (!el || !handle) return undefined;
+
+        const cleanupDraggable = draggable({
+            element: el,
+            dragHandle: handle,
+            getInitialData: () => ({ type: 'group', groupId: group.id }),
+            onDragStart: () => setIsDragging(true),
+            onDrop: () => setIsDragging(false),
+        });
+
+        const cleanupDropTarget = dropTargetForElements({
+            element: el,
+            getData: ({ input, element, source }) => {
+                if (source.data.type === 'group') {
+                    return attachClosestEdge(
+                        { type: 'group', groupId: group.id },
+                        { element, input, allowedEdges: ['top', 'bottom'] },
+                    );
+                }
+                // For mocks being dropped onto the group
+                return { type: 'group', groupId: group.id };
+            },
+            onDragEnter: ({ self, source }) => {
+                if (source.data.type === 'mock') {
+                    setIsMockDraggedOver(true);
+                } else {
+                    const edge = extractClosestEdge(self.data);
+                    setClosestEdge(edge === 'bottom' && !isLast ? null : edge);
+                }
+            },
+            onDrag: ({ self, source }) => {
+                if (source.data.type === 'mock') {
+                    setIsMockDraggedOver(true);
+                } else {
+                    const edge = extractClosestEdge(self.data);
+                    setClosestEdge(edge === 'bottom' && !isLast ? null : edge);
+                }
+            },
+            onDragLeave: () => {
+                setClosestEdge(null);
+                setIsMockDraggedOver(false);
+            },
+            onDrop: () => {
+                setClosestEdge(null);
+                setIsMockDraggedOver(false);
+            },
+        });
+
+        return () => {
+            cleanupDraggable();
+            cleanupDropTarget();
+        };
+    }, [group.id, isLast]);
 
     // Sync the internal state with the external isExpanded prop
     useEffect(() => {
@@ -69,83 +139,101 @@ export const MockGroup: FC<MockGroupProps> = ({
     const allDisabled = mocks.every((item) => !item.isActive);
 
     return (
-        <div className={styles.root}>
-            <Group justify="space-between">
-                <Group gap="0">
-                    {children ? (
-                        <Text
-                            ml="xs"
-                            className={styles.groupName}
-                            onClick={handleToggle}
-                        >
-                            {group.name} {isOpen ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />}
-                        </Text>
-                    ) : (
-                        <Text ml="xs">{group.name}</Text>
-                    )}
-                </Group>
-
-                <Menu
-                    withinPortal
-                    position="bottom-end"
-                    shadow="sm"
-                >
-                    <Menu.Target>
+        <div style={{ position: 'relative' }}>
+            <div
+                className={`${styles.root} ${isMockDraggedOver ? styles.draggedOver : ''}`}
+                ref={ref}
+                style={{ opacity: isDragging ? 0.4 : undefined }}
+            >
+                <Group justify="space-between">
+                    <Group gap="0">
                         <ActionIcon
+                            ref={dragHandleRef}
+                            className={styles.dragHandle}
                             variant="subtle"
                             color="gray"
+                            size="sm"
                         >
-                            <IconDotsVertical size={14} />
+                            <IconGripVertical size={14} />
                         </ActionIcon>
-                    </Menu.Target>
-
-                    <Menu.Dropdown>
-                        {mocks.length > 0 && (
-                            <>
-                                <Menu.Item
-                                    leftSection={<IconPower size={14} />}
-                                    disabled={allEnabled}
-                                    onClick={handleEnableAll}
-                                >
-                                    Enable all
-                                </Menu.Item>
-                                <Menu.Item
-                                    leftSection={<IconCircleOff size={12} />}
-                                    disabled={allDisabled}
-                                    onClick={handleDisableAll}
-                                >
-                                    Disable all
-                                </Menu.Item>
-
-                                <Menu.Divider />
-                                <Menu.Label>Danger zone</Menu.Label>
-
-                                <Menu.Item
-                                    leftSection={<IconTrash size={12} />}
-                                    color="red"
-                                    onClick={handleRemoveMocks}
-                                >
-                                    Remove mocks from group
-                                </Menu.Item>
-                            </>
+                        
+                        {children ? (
+                            <Text
+                                ml="xs"
+                                className={styles.groupName}
+                                onClick={handleToggle}
+                            >
+                                {group.name} {isOpen ? <IconChevronUp size={14} /> : <IconChevronDown size={14} />}
+                            </Text>
+                        ) : (
+                            <Text ml="xs">{group.name}</Text>
                         )}
+                    </Group>
 
-                        <Menu.Item
-                            leftSection={<IconTrash size={12} />}
-                            color="red"
-                            onClick={() => onDeleteGroup(group)}
-                        >
-                            Delete group
-                        </Menu.Item>
-                    </Menu.Dropdown>
-                </Menu>
-            </Group>
+                    <Menu
+                        withinPortal
+                        position="bottom-end"
+                        shadow="sm"
+                    >
+                        <Menu.Target>
+                            <ActionIcon
+                                variant="subtle"
+                                color="gray"
+                            >
+                                <IconDotsVertical size={14} />
+                            </ActionIcon>
+                        </Menu.Target>
 
-            {children && (
-                <Collapse in={isOpen}>
-                    <div className={styles.content}>{children}</div>
-                </Collapse>
-            )}
+                        <Menu.Dropdown>
+                            {mocks.length > 0 && (
+                                <>
+                                    <Menu.Item
+                                        leftSection={<IconPower size={14} />}
+                                        disabled={allEnabled}
+                                        onClick={handleEnableAll}
+                                    >
+                                        Enable all
+                                    </Menu.Item>
+                                    <Menu.Item
+                                        leftSection={<IconCircleOff size={12} />}
+                                        disabled={allDisabled}
+                                        onClick={handleDisableAll}
+                                    >
+                                        Disable all
+                                    </Menu.Item>
+
+                                    <Menu.Divider />
+                                    <Menu.Label>Danger zone</Menu.Label>
+
+                                    <Menu.Item
+                                        leftSection={<IconTrash size={12} />}
+                                        color="red"
+                                        onClick={handleRemoveMocks}
+                                    >
+                                        Remove mocks from group
+                                    </Menu.Item>
+                                </>
+                            )}
+
+                            <Menu.Item
+                                leftSection={<IconTrash size={12} />}
+                                color="red"
+                                onClick={() => onDeleteGroup(group)}
+                            >
+                                Delete group
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                </Group>
+
+                {children && (
+                    <Collapse key={mocks.length} in={isOpen}>
+                        <div className={styles.content}>{children}</div>
+                    </Collapse>
+                )}
+            </div>
+            
+            {closestEdge && <DropIndicator edge={closestEdge} gap="0.25rem" />}
         </div>
     );
 };

--- a/src/utils/filterMocks.ts
+++ b/src/utils/filterMocks.ts
@@ -1,55 +1,39 @@
 import { TMock, TMockGroup } from '../types';
 
-type GroupId = string;
-
-type MocksByGroupsRecord = Record<
-    GroupId,
-    {
-        group: TMockGroup;
-        mocks: TMock[];
-    }
->;
+type GroupWithMocks = {
+    group: TMockGroup;
+    mocks: TMock[];
+};
 
 type FilteredMocks = {
-    mocksByGroups: MocksByGroupsRecord;
-    emptyMocks: TMock[];
-    emptyGroups: TMockGroup[];
+    groupsWithMocks: GroupWithMocks[];
+    ungroupedMocks: TMock[];
 };
 
 export const filterMocks = (mocks: TMock[], groups: TMockGroup[]): FilteredMocks => {
-    const usedGroupsIds = new Set<GroupId>();
-    const mocksByGroups: MocksByGroupsRecord = {};
-    const emptyMocks: TMock[] = [];
+    const mocksByGroupId = new Map<string, TMock[]>();
 
-    const groupsById: Record<GroupId, TMockGroup> = groups.reduce((acc, group) => {
-        return {
-            ...acc,
-            [group.id]: group,
-        };
-    }, {});
+    const ungroupedMocks: TMock[] = [];
 
     mocks?.forEach((mock) => {
         if (!mock.groupId) {
-            emptyMocks.push(mock);
+            ungroupedMocks.push(mock);
         } else {
-            if (!mocksByGroups[mock.groupId]) {
-                mocksByGroups[mock.groupId] = {
-                    group: groupsById[mock.groupId],
-                    mocks: [],
-                };
+            if (!mocksByGroupId.has(mock.groupId)) {
+                mocksByGroupId.set(mock.groupId, []);
             }
-
-            mocksByGroups[mock.groupId].mocks.push(mock);
-            usedGroupsIds.add(mock.groupId);
+            mocksByGroupId.get(mock.groupId)!.push(mock);
         }
     });
 
-    // Filter groups without mocks
-    const emptyGroups = (groups ?? []).filter((group) => !usedGroupsIds.has(group.id));
+    // All groups in their original order, with their mocks (or empty array)
+    const groupsWithMocks: GroupWithMocks[] = groups.map((group) => ({
+        group,
+        mocks: mocksByGroupId.get(group.id) ?? [],
+    }));
 
     return {
-        mocksByGroups,
-        emptyMocks,
-        emptyGroups,
+        groupsWithMocks,
+        ungroupedMocks,
     };
 };


### PR DESCRIPTION
## Summary

Implement drag-and-drop reordering for mocks and groups on the Mocks page using Atlassian’s pragmatic DnD, plus UX tweaks and data-structure refactors to support grouped/ungrouped mocks.

## Related

Fixes #47 .